### PR TITLE
Add scene changer

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -16,7 +16,12 @@ _global_script_class_icons={
 [application]
 
 config/name="Game"
+run/main_scene="res://scenes/Intro.tscn"
 config/icon="res://icon.png"
+
+[autoload]
+
+SceneChanger="*res://scenes/SceneChanger.tscn"
 
 [rendering]
 

--- a/game/scenes/Intro.tscn
+++ b/game/scenes/Intro.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scripts/Intro.gd" type="Script" id=1]
+
+[node name="Spatial" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 3.9032 )

--- a/game/scenes/SceneChanger.tscn
+++ b/game/scenes/SceneChanger.tscn
@@ -1,0 +1,37 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://scripts/SceneChanger.gd" type="Script" id=1]
+
+[sub_resource type="Animation" id=1]
+resource_name = "fade"
+step = 1.0
+tracks/0/type = "value"
+tracks/0/path = NodePath("Control/Black:color")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 1 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ Color( 0, 0, 0, 0 ), Color( 0, 0, 0, 1 ) ]
+}
+
+[node name="SceneChanger" type="CanvasLayer"]
+script = ExtResource( 1 )
+
+[node name="Control" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Black" type="ColorRect" parent="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color( 0, 0, 0, 0 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+anims/fade = SubResource( 1 )

--- a/game/scripts/Intro.gd
+++ b/game/scripts/Intro.gd
@@ -1,0 +1,5 @@
+extends Spatial
+
+
+func _ready():
+    SceneChanger.change_scene("res://scenes/Arm_test.tscn", 0.5)

--- a/game/scripts/SceneChanger.gd
+++ b/game/scripts/SceneChanger.gd
@@ -1,0 +1,18 @@
+extends CanvasLayer
+
+signal scene_changed()
+
+onready var animation_player = $AnimationPlayer
+onready var black = $Control/Black
+
+
+func change_scene(path, delay=0.5):
+    yield(get_tree().create_timer(delay), "timeout")
+
+    animation_player.play("fade")
+    yield(animation_player, "animation_finished")
+
+    assert(get_tree().change_scene(path) == OK)
+
+    animation_player.play_backwards("fade")
+    emit_signal("scene_changed")


### PR DESCRIPTION
SceneChanger object kan vanuit elk script aangeroepen worden.

```gdscript
SceneChanger.change_scene("path/to/scene.tscn", delay=0.5)
```

Wanneer de transitie is voltooid, zendt SceneChanger het signaal ``scene_changed`` uit.

Schaamteloos gekopieerd van [hier](https://www.youtube.com/watch?v=_4_DVbZwmYc&feature=emb_logo).